### PR TITLE
fix: throw correct abort error

### DIFF
--- a/src/eventManager/eventManager.ts
+++ b/src/eventManager/eventManager.ts
@@ -308,15 +308,24 @@ export class AdvancedPostMessage {
     };
     this.requestMessageHandlers.set(type, requestListener);
 
+    const unregisterCallbackController = new AbortController();
+
     if (signal) {
-      signal.addEventListener("abort", () => {
-        this.unregisterEvent(type);
-      });
+      signal.addEventListener(
+        "abort",
+        () => {
+          this.unregisterEvent(type);
+        },
+        {
+          signal: unregisterCallbackController.signal,
+        }
+      );
     }
 
     return {
       unregister: () => {
         this.unregisterEvent(type);
+        unregisterCallbackController.abort();
       },
     };
   }

--- a/src/eventManager/eventManager.ts
+++ b/src/eventManager/eventManager.ts
@@ -233,7 +233,10 @@ export class AdvancedPostMessage {
       }
       if (responseListener.hasCancelled) {
         return promise.reject(
-          new Error(getErrorMessage(ERROR_MESSAGES.sendEvent.eventCancelled))
+          new DOMException(
+            getErrorMessage(ERROR_MESSAGES.sendEvent.eventCancelled),
+            "AbortError"
+          )
         );
       }
 


### PR DESCRIPTION
When an operation is aborted, the error should be thrown as an
AbortError instead of an Error.